### PR TITLE
Query inclusion of network range

### DIFF
--- a/include/CLookUp_ANN.hpp
+++ b/include/CLookUp_ANN.hpp
@@ -243,7 +243,8 @@ public:
 
       mlpdouble distance_to_query_i = 0;
       for (auto i_input = 0u; i_input < ANN_inputs.size(); i_input++) {
-        within_range = NeuralNetworks[i_ANN].CheckInputInclusion(ANN_inputs[i_input], i_input);
+        if (!NeuralNetworks[i_ANN].CheckInputInclusion(ANN_inputs[i_input], i_input))
+          within_range = false;
         
 
         /* Calculate distance between MLP training range center point and query


### PR DESCRIPTION
Fixed a bug where the inclusion of the query in the range of the network inputs was incorrectly determined. 

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] The derivatives calculated in the test case according to finite-differences and the network output match.
- [X] I have sufficiently commented my changes.
