### PR TITLE
Fix outofbounds

### DIFF
--- a/RegressionTests/input_output_mapping.cpp
+++ b/RegressionTests/input_output_mapping.cpp
@@ -226,12 +226,78 @@ bool InputOutputMapping::NullOutputs() {
     delete mlp_1;
     return passed_test;
 }
+
+bool InputOutputMapping::VectorInputOutputs() {
+    /* Define two randomized MLPs */
+    std::vector<std::string> input_names_1 = {"a","b"}, output_names_1 = {"x", "y"},
+                             input_names_2 = {"b","a"}, output_names_2 = {"z"};
+    MLPToolbox::CNeuralNetwork * mlp_1 = CreateRandomNetwork(input_names_1, output_names_1);
+    MLPToolbox::CNeuralNetwork * mlp_2 = CreateRandomNetwork(input_names_2, output_names_2);
+
+    MLPToolbox::CLookUp_ANN mlp_collection;
+    mlp_collection.AddNetwork(mlp_1);
+    mlp_collection.AddNetwork(mlp_2);
+
+    /* Define query variables*/
+    MLPToolbox::CIOMap query_memberwise, query_vector;
+
+    double val_a, val_b, val_x_m, val_y_m, val_z_m, val_null_m, val_x_v, val_y_v, val_z_v,val_null_v;
+    val_a = 0.2;
+    val_b = 0.8;
+
+    /* Specify query input and output variables through vectors */
+    std::vector<std::string> input_vec = {"a", "b"};
+    std::vector<std::string> output_vec = {"x","y","z","null"};
+    std::vector<double*> refs_out_vec = {&val_x_v, &val_y_v, &val_z_v, &val_null_v};
+    query_vector.SetQueryInput(input_vec);
+    query_vector.SetQueryOutput(output_vec);
+
+    /* Specify query variables member-wise. */
+    query_memberwise.AddQueryInput("a", &val_a);
+    query_memberwise.AddQueryInput("b", &val_b);
+    query_memberwise.AddQueryOutput("x", &val_x_m);
+    query_memberwise.AddQueryOutput("y", &val_y_m);
+    query_memberwise.AddQueryOutput("z", &val_z_m);
+    query_memberwise.AddQueryOutput("null", &val_null_m);
+    
+    mlp_collection.PairVariableswithMLPs(query_memberwise);
+    mlp_collection.PairVariableswithMLPs(query_vector);
+    
+    /* Evaluate network output */
+    std::vector<double> vals_in_vec = {val_a, val_b};
+    bool inside_m = mlp_collection.Predict(query_memberwise);
+    bool inside_v = mlp_collection.Predict(query_vector, vals_in_vec, refs_out_vec);
+
+    bool passed_test{true};
+    if (inside_m != inside_v){
+        passed_test = false;
+        summary << "Member-wise and vector-wise query input returns different inclusion.\n";
+    }
+    if (val_x_v != val_x_m && val_y_v != val_y_m && val_z_v != val_z_m) {
+        passed_test = false;
+        summary << "Member-wise and vector-wise query input returns different output:\n";
+        summary << "Member-wise: x:" << val_x_m << " y: " << val_y_m << " z: " << val_z_m << std::endl;
+        summary << "Vector-wise: x:" << val_x_v << " y: " << val_y_v << " z: " << val_z_v << std::endl;
+    }
+    if (val_null_m != 0.0) {
+        passed_test = false;
+        summary << "Member-wise null assignment returns non-zero value: " << val_null_m << std::endl;
+    }
+    if (val_null_v != 0.0) {
+        passed_test = false;
+        summary << "Vector-wise null assignment returns non-zero value: " << val_null_v << std::endl;
+    }
+    delete mlp_1;
+    delete mlp_2;
+    return passed_test;
+}
 bool InputOutputMapping::RunTest() {
     bool test_multiple_inputs = DifferentInputsDifferentOutputs();
     bool test_multiple_outputs = SameInputsDifferentOutputs();
     bool test_mimo = DifferentInputsDifferentOutputs2();
     bool test_null = NullOutputs();
-    
-    passed = (test_multiple_inputs && test_multiple_outputs && test_mimo && test_null);
+    bool test_vectorwise = VectorInputOutputs();
+
+    passed = (test_multiple_inputs && test_multiple_outputs && test_mimo && test_null && test_vectorwise);
     return passed;
 };

--- a/RegressionTests/network_output_tests.cpp
+++ b/RegressionTests/network_output_tests.cpp
@@ -20,8 +20,8 @@ bool OutputCorrectness::CopyConstructorTest() {
 
     delete mlp;
     bool passed = (network_output_ref == network_output_copy);
-
-    summary << "From copy constructor: " << (passed ? "Passed" : "Failed") << std::endl;
+    if (!passed)
+        summary << "From copy constructor: " << (passed ? "Passed" : "Failed") << std::endl;
     return passed;
 }
 
@@ -39,7 +39,8 @@ bool OutputCorrectness::FileWriterReaderTest() {
     double outp_read = mlp_from_file.GetOutput(0);
     delete mlp;
     bool passed = (outp_ref == outp_read);
-    summary << "From writing-reading input file: " << (passed ? "Passed" : "Failed") << std::endl;
+    if (!passed)
+        summary << "From writing-reading input file: " << (passed ? "Passed" : "Failed") << std::endl;
     return passed;
 
 }
@@ -59,8 +60,46 @@ bool OutputCorrectness::WeightsBiasesTest() {
 
     delete mlp;
     bool passed = (outp_ref == outp_copy);
-    summary << "From weights and biases test: " << (passed ? "Passed" : "Failed") << std::endl;
+    if (!passed)
+        summary << "From weights and biases test: " << (passed ? "Passed" : "Failed") << std::endl;
     return passed;
+}
+
+bool OutputCorrectness::VectorInputOutputs() {
+
+    /* Create randomized network and a vector with random inputs. */
+    MLPToolbox::CNeuralNetwork * mlp = CreateRandomNetwork();
+    std::vector<double> network_inputs_vec = RandomInputs(mlp->GetnInputs());
+    
+    mlp->Predict(network_inputs_vec);
+
+    const double output_ref = mlp->GetOutput(0);
+
+    /* Reset network output */
+    mlp->Predict(RandomInputs(mlp->GetnInputs()));
+
+    /* Set network input member-wise. */
+    for (auto iInput=0u; iInput < network_inputs_vec.size(); iInput++)
+        mlp->SetInput(iInput, network_inputs_vec[iInput]);
+
+    mlp->Predict();
+
+    const double output_p = mlp->GetOutput(0);
+
+    /* Outputs from vector and piece-wise input should be the same. */
+    bool passed_test = (output_ref == output_p);
+
+    if (!passed_test) {
+        mlp->DisplayNetwork(summary);
+        summary << "Network input values: \n";
+        for (auto iInput=0u; iInput<mlp->GetnInputs(); iInput++)
+            summary << mlp->GetInputName(iInput) << " : " << network_inputs_vec[iInput] << std::endl;
+        summary << "Network output from vector input: " << output_ref << std::endl;
+        summary << "Network output from piece-wise input: " << output_p << std::endl;
+    }
+    delete mlp;
+    return passed_test;
+    
 }
 
 bool OutputCorrectness::RunTest() {
@@ -68,7 +107,8 @@ bool OutputCorrectness::RunTest() {
     bool passed_copy = CopyConstructorTest();
     bool passed_file = FileWriterReaderTest();
     bool passed_weights = WeightsBiasesTest();
+    bool passed_vector = VectorInputOutputs();
 
-    passed = (passed_copy && passed_file && passed_weights);
+    passed = (passed_copy && passed_file && passed_weights && passed_vector);
     return passed;
 }

--- a/RegressionTests/unit_test.hpp
+++ b/RegressionTests/unit_test.hpp
@@ -49,6 +49,9 @@ class InputOutputMapping : public UnitTest {
     /*! \brief Link multiple networks with different inputs and outputs to the same query. */
     bool DifferentInputsDifferentOutputs2();
 
+    /*! \brief Setting query inputs through vector or by reference should result in the same network output. */
+    bool VectorInputOutputs();
+    
     /*! \brief Query containing null variables. */
     bool NullOutputs();
 

--- a/RegressionTests/unit_test.hpp
+++ b/RegressionTests/unit_test.hpp
@@ -29,6 +29,10 @@ class OutputCorrectness : public UnitTest {
 
     /*! \brief Network with same weights and biases should have the same output */
     bool WeightsBiasesTest();
+
+    /*! \brief Passing network input through vector or member-wise should result in the same output. */
+    bool VectorInputOutputs();
+    
     public:
     OutputCorrectness() : UnitTest("Output correctness") {};
     virtual bool RunTest();

--- a/include/CIOMap.hpp
+++ b/include/CIOMap.hpp
@@ -660,10 +660,10 @@ class CIOMap {
       if (refs_output.size() != query_output_vals.size()){
         ErrorMessage("Number of outputs in query differs from number of requested outputs.", "CIOMap:operator()");
       }
-      bool within_bounds{false};
+      bool within_bounds{true};
       for (const auto &mapped_network : query_network_maps) {
         SetNetworkInputs(mapped_network, vals_input);
-        if (NetworkInference(mapped_network)) within_bounds=true;
+        if (!NetworkInference(mapped_network)) within_bounds=true;
       }
       SetNullOutputs();
 


### PR DESCRIPTION
## Proposed Changes
Fixed a bug where vector-wise NULL queries would always return out-of bounds. Added a regression test that compares vector-wise and member-wise queries.




## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] I have added a unit/regression test, if applicable.
- [x] I have sufficiently commented my changes.
- [x] My code does not generate any compiler warnings when compiling ```main.cpp``` with the ```-Wall``` flag.